### PR TITLE
feat: move logout to the top bar + fix client port mapping for the VPS

### DIFF
--- a/Lootopia.Client/package-lock.json
+++ b/Lootopia.Client/package-lock.json
@@ -42,6 +42,7 @@
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.1",
         "@types/leaflet": "^1.9.21",
+        "@types/node": "^22.0.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "tailwindcss": "^4.2.1",
@@ -4719,6 +4720,16 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -8220,6 +8231,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/Lootopia.Client/src/app/play/profile/ProfilePage.tsx
+++ b/Lootopia.Client/src/app/play/profile/ProfilePage.tsx
@@ -1,7 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
-import { User, LogOut, Mail, Shield } from "lucide-react";
+import { User, Mail, Shield } from "lucide-react";
 import { Card, CardContent } from "@/shared/components/ui/card";
-import { Button } from "@/shared/components/ui/button";
 import { Skeleton } from "@/shared/components/ui/skeleton";
 import { useAuth } from "@/shared/providers/AuthProvider";
 import { achievementsApi } from "@/shared/api/achievements";
@@ -14,7 +13,7 @@ const RARITY_COLORS: Record<string, string> = {
 };
 
 export function ProfilePage() {
-  const { user, logout } = useAuth();
+  const { user } = useAuth();
 
   const { data: achievements, isLoading } = useQuery({
     queryKey: ["achievements"],
@@ -96,16 +95,6 @@ export function ProfilePage() {
         )}
       </div>
 
-      <div className="mt-auto pt-4">
-        <Button
-          variant="outline"
-          className="w-full border-destructive/50 text-destructive hover:bg-destructive/10"
-          onClick={logout}
-        >
-          <LogOut className="h-5 w-5 mr-2" />
-          Se déconnecter
-        </Button>
-      </div>
     </div>
   );
 }

--- a/Lootopia.Client/src/shared/components/Layout/MobileLayout.tsx
+++ b/Lootopia.Client/src/shared/components/Layout/MobileLayout.tsx
@@ -1,6 +1,6 @@
 import { NavLink, Outlet } from "react-router";
 import { useQuery } from "@tanstack/react-query";
-import { Map, Backpack, Store, Trophy, User, Wallet, Bell } from "lucide-react";
+import { Map, Backpack, Store, Trophy, User, Wallet, Bell, LogOut } from "lucide-react";
 import { useAuth } from "@/shared/providers/AuthProvider";
 import { walletApi } from "@/shared/api/wallet";
 import { cn, formatCurrency } from "@/shared/lib/utils";
@@ -14,7 +14,7 @@ const navItems = [
 ];
 
 export function MobileLayout() {
-  const { user } = useAuth();
+  const { user, logout } = useAuth();
 
   const { data: wallet } = useQuery({
     queryKey: ["wallet"],
@@ -42,9 +42,19 @@ export function MobileLayout() {
             <Bell className="h-5 w-5 text-muted-foreground" />
           </NavLink>
           {user && (
-            <span className="text-xs text-muted-foreground truncate max-w-[80px]">
-              {user.displayName}
-            </span>
+            <>
+              <span className="text-xs text-muted-foreground truncate max-w-[80px]">
+                {user.displayName}
+              </span>
+              <button
+                onClick={logout}
+                aria-label="Se déconnecter"
+                title="Se déconnecter"
+                className="text-muted-foreground hover:text-destructive transition-colors"
+              >
+                <LogOut className="h-5 w-5" />
+              </button>
+            </>
           )}
         </div>
       </header>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,8 @@ services:
     container_name: lootopia-client
     restart: always
     ports:
-      - "80:80"
+      # 8081 et non 80 : sur le VPS, Caddy occupe le port 80 et proxifie :80 -> 127.0.0.1:8081
+      - "8081:80"
       - "3000:80"
     depends_on:
       - api


### PR DESCRIPTION
## Quoi

- **Déconnexion dans la barre du haut** (côté joueur) : le bouton logout est maintenant à côté du nom d'utilisateur en haut à droite, au lieu d'être en bas de la page Profil. Même pattern que la sidebar admin/partenaire (icône `LogOut`, hover destructive, `aria-label`).
- **Suppression du bouton en bas de ProfilePage** + nettoyage des imports. Supprime au passage une classe CSS cassée (`border-destructive\50`).
- **`docker-compose.yml` : client mappé sur `8081:80`** au lieu de `80:80` — le port 80 du VPS appartient à Caddy, qui proxifie `:80` et `lootopia.site` vers `127.0.0.1:8081`. Aligne le repo sur le fix déjà appliqué en prod (le front était tombé 3 jours à cause de ce conflit).
- Resync de `package-lock.json` (`@types/node` déclaré dans `package.json` mais absent du lockfile).

## Vérification

- `tsc --noEmit` ✅
- `npm run build` ✅ (build Vite + PWA complet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)