### PR TITLE
fix: ZQSD/arrow keys unusable in form fields when GPS debug mode is on

### DIFF
--- a/Lootopia.Client/src/shared/providers/GeolocationProvider.tsx
+++ b/Lootopia.Client/src/shared/providers/GeolocationProvider.tsx
@@ -148,7 +148,19 @@ export function GeolocationProvider({ children }: { children: ReactNode }) {
       raf = requestAnimationFrame(tick);
     };
 
+    // Let ZQSD/arrows through when the user is typing in a form field
+    const isTypingTarget = (e: KeyboardEvent) => {
+      const el = e.target as HTMLElement | null;
+      return (
+        el instanceof HTMLInputElement ||
+        el instanceof HTMLTextAreaElement ||
+        el instanceof HTMLSelectElement ||
+        (el?.isContentEditable ?? false)
+      );
+    };
+
     const onDown = (e: KeyboardEvent) => {
+      if (isTypingTarget(e)) return;
       const key = e.key.toLowerCase();
       if (["z", "q", "s", "d", "arrowup", "arrowdown", "arrowleft", "arrowright"].includes(key)) {
         e.preventDefault();


### PR DESCRIPTION
## Problème

Avec le mode debug GPS actif (`Ctrl+Shift+D`), l'écouteur clavier global capturait `z/q/s/d` et les flèches avec `preventDefault()` **sans vérifier où était le focus**. Impossible par exemple de taper un email contenant ces lettres dans le formulaire de connexion.

## Fix

L'écouteur ignore désormais les événements provenant d'un champ de saisie (`input`, `textarea`, `select`, `contentEditable`) :

- ✅ les touches fonctionnent normalement dans tous les formulaires de l'app
- ✅ le déplacement debug ZQSD/flèches fonctionne toujours dès que le focus est hors d'un champ
- ✅ le relâchement d'une touche est toujours pris en compte, même dans un champ (pas de déplacement « coincé »)

## Vérification

- `tsc --noEmit` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)